### PR TITLE
Fix strong params for todo items

### DIFF
--- a/app/controllers/todo_items_controller.rb
+++ b/app/controllers/todo_items_controller.rb
@@ -7,6 +7,14 @@ class TodoItemsController < ApplicationController
     redirect_to @todo_list
   end
 
+  def update
+    if @todo_item.update(todo_item_params)
+      redirect_to @todo_list
+    else
+      redirect_to @todo_list, alert: "Todo item couldn't be updated."
+    end
+  end
+
   def destroy
     @todo_item = @todo_list.todo_items.find(params[:id])
     if @todo_item.destroy
@@ -33,6 +41,6 @@ class TodoItemsController < ApplicationController
   end
 
   def todo_item_params
-    params[:todo_item].permit(:content)
+    params.require(:todo_item).permit(:content)
   end
 end

--- a/app/models/todo_item.rb
+++ b/app/models/todo_item.rb
@@ -1,6 +1,8 @@
 class TodoItem < ApplicationRecord
   belongs_to :todo_list
 
+  validates :content, presence: true
+
   def completed?
     !completed_at.blank?
   end

--- a/test/controllers/todo_items_controller_test.rb
+++ b/test/controllers/todo_items_controller_test.rb
@@ -1,7 +1,38 @@
 require 'test_helper'
 
 class TodoItemsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @todo_list = todo_lists(:one)
+    @todo_item = todo_items(:one)
+  end
+
+  test 'create requires todo_item param' do
+    assert_raises(ActionController::ParameterMissing) do
+      post todo_list_todo_items_path(@todo_list), params: {}
+    end
+  end
+
+  test 'create requires content' do
+    assert_no_difference('TodoItem.count') do
+      post todo_list_todo_items_path(@todo_list), params: { todo_item: {} }
+    end
+  end
+
+  test 'update requires todo_item param' do
+    assert_raises(ActionController::ParameterMissing) do
+      patch todo_list_todo_item_path(@todo_list, @todo_item), params: {}
+    end
+  end
+
+  test 'update requires content' do
+    original = @todo_item.content
+    patch todo_list_todo_item_path(@todo_list, @todo_item), params: { todo_item: {} }
+    assert_equal original, @todo_item.reload.content
+  end
+
+  test 'update with valid content changes item and redirects' do
+    patch todo_list_todo_item_path(@todo_list, @todo_item), params: { todo_item: { content: 'Updated content' } }
+    assert_redirected_to todo_list_path(@todo_list)
+    assert_equal 'Updated content', @todo_item.reload.content
+  end
 end


### PR DESCRIPTION
## Summary
- validate presence of todo item content
- add update action and controller tests for strong params
- add test verifying successful update with valid content

## Testing
- `bundle exec rake test` *(fails: Bundler::RubyVersionMismatch)*
